### PR TITLE
Debug the mia_z3_zscore

### DIFF
--- a/main_functions/mia_s3_zscore.m
+++ b/main_functions/mia_s3_zscore.m
@@ -92,6 +92,12 @@ for ii=1:length(sInputs)
             [F, labels] = mia_make_bipolarmtg(F,labels);
         end
         
+        % Compute monopolar montage if needed
+        if strcmpi(OPTIONS.mtg,'MONOPOLAR')
+            F = data.F ; 
+            labels = data.labels ; 
+        end
+        
         Time = data.Time ;
     
         % Calcule zScore


### PR DESCRIPTION
Debug the mia_z3_zscore function for handling computation of lfp with monopolar montage and NO bad channels